### PR TITLE
Add UnsupportedCommand: Handling unsupported additional behavior of git operations in JGit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-client</artifactId>
+      <version>3.3.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -853,14 +853,14 @@ public class GitSCM extends GitSCMBackwardCompatibility {
         }
 
         listener.getLogger().println("Using Performance Improvement");
-        GitToolChooser estimator = null;
+        GitToolChooser chooser = null;
         for (UserRemoteConfig uc : getUserRemoteConfigs()) {
             String url = getParameterString(uc.getUrl(), environment);
-            estimator = new GitToolChooser(url, unsupportedCommand.determineSupportForJGit());
+            chooser = new GitToolChooser(url, unsupportedCommand.determineSupportForJGit());
         }
-        listener.getLogger().println("The recommended git tool is: " + estimator.getGitTool());
+        listener.getLogger().println("The recommended git tool is: " + chooser.getGitTool());
 
-        gitExe = estimator.getGitTool();
+        gitExe = chooser.getGitTool();
         Git git = Git.with(listener, environment).in(ws).using(gitExe);
 
         GitClient c = git.getClient();

--- a/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
+++ b/src/main/java/hudson/plugins/git/extensions/GitSCMExtension.java
@@ -29,6 +29,7 @@ import org.jenkinsci.plugins.gitclient.CloneCommand;
 import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.gitclient.MergeCommand;
+import org.jenkinsci.plugins.gitclient.UnsupportedCommand;
 
 /**
  * Extension point to tweak the behaviour of {@link GitSCM}.
@@ -231,6 +232,15 @@ public abstract class GitSCMExtension extends AbstractDescribableImpl<GitSCMExte
      */
     public GitClient decorate(GitSCM scm, GitClient git) throws IOException, InterruptedException, GitException {
         return git;
+    }
+
+    /**
+     * Called when support of JGit for a particular or multiple extensions is to be determined
+     * @param scm GitSCM object
+     * @param unsupportedCommand UnsupportedCommand object
+     */
+    public void determineSupportForJGit(GitSCM scm, UnsupportedCommand unsupportedCommand) {
+
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/extensions/impl/CheckoutOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CheckoutOption.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.Objects;
 import org.jenkinsci.plugins.gitclient.CheckoutCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.gitclient.UnsupportedCommand;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -47,6 +48,11 @@ public class CheckoutOption extends FakeGitSCMExtension {
      */
     @Override
     public void decorateCheckoutCommand(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, CheckoutCommand cmd) throws IOException, InterruptedException, GitException {
+        cmd.timeout(timeout);
+    }
+
+    @Override
+    public void determineSupportForJGit(GitSCM scm, UnsupportedCommand cmd) {
         cmd.timeout(timeout);
     }
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/CloneOption.java
@@ -21,6 +21,7 @@ import org.eclipse.jgit.transport.RemoteConfig;
 import org.jenkinsci.plugins.gitclient.CloneCommand;
 import org.jenkinsci.plugins.gitclient.FetchCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.gitclient.UnsupportedCommand;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -191,6 +192,13 @@ public class CloneOption extends GitSCMExtension {
     @Override
     public GitClientType getRequiredClient() {
         return GitClientType.GITCLI;
+    }
+
+    @Override
+    public void determineSupportForJGit(GitSCM scm, UnsupportedCommand cmd) {
+        cmd.timeout(timeout);
+        cmd.shallow(shallow);
+        cmd.depth(depth);
     }
 
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/GitLFSPull.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/GitLFSPull.java
@@ -9,9 +9,12 @@ import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import java.io.IOException;
 import java.util.List;
+
+import jenkins.plugins.git.GitToolChooser;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.jenkinsci.plugins.gitclient.CheckoutCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.gitclient.UnsupportedCommand;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -42,6 +45,12 @@ public class GitLFSPull extends GitSCMExtension {
             // in a single job definition.
             cmd.lfsRemote(repos.get(0).getName());
         }
+    }
+
+    @Override
+    public void determineSupportForJGit(GitSCM scm, UnsupportedCommand cmd) {
+        List<RemoteConfig> repos = scm.getRepositories();
+        cmd.lfsRemote(repos.get(0).getName());
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPaths.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SparseCheckoutPaths.java
@@ -8,9 +8,11 @@ import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+import jenkins.plugins.git.GitToolChooser;
 import org.jenkinsci.plugins.gitclient.CheckoutCommand;
 import org.jenkinsci.plugins.gitclient.CloneCommand;
 import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.gitclient.UnsupportedCommand;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -41,6 +43,11 @@ public class SparseCheckoutPaths extends GitSCMExtension {
 
     @Override
     public void decorateCheckoutCommand(GitSCM scm, Run<?, ?> build, GitClient git, TaskListener listener, CheckoutCommand cmd) throws IOException, InterruptedException, GitException {
+        cmd.sparseCheckoutPaths(Lists.transform(sparseCheckoutPaths, SparseCheckoutPath.SPARSE_CHECKOUT_PATH_TO_PATH));
+    }
+
+    @Override
+    public void determineSupportForJGit(GitSCM scm, UnsupportedCommand cmd) {
         cmd.sparseCheckoutPaths(Lists.transform(sparseCheckoutPaths, SparseCheckoutPath.SPARSE_CHECKOUT_PATH_TO_PATH));
     }
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/SubmoduleOption.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.Objects;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand;
+import org.jenkinsci.plugins.gitclient.UnsupportedCommand;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -128,6 +129,16 @@ public class SubmoduleOption extends GitSCMExtension {
         if (!disableSubmodules && git.hasGitModules()) {
             git.submoduleClean(recursiveSubmodules);
         }
+    }
+
+    @Override
+    public void determineSupportForJGit(GitSCM scm, UnsupportedCommand cmd) {
+        cmd.threads(threads);
+        cmd.depth(depth);
+        cmd.shallow(shallow);
+        cmd.timeout(timeout);
+        cmd.ref(reference);
+        cmd.parentCredentials(parentCredentials);
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/extensions/impl/impl.plantuml
+++ b/src/main/java/hudson/plugins/git/extensions/impl/impl.plantuml
@@ -1,0 +1,956 @@
+@startuml
+
+title __IMPL's Class Diagram__\n
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.AuthorInChangelog {
+              + AuthorInChangelog()
+              + equals()
+              + hashCode()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.AuthorInChangelog.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.BuildChooserSetting {
+              + BuildChooserSetting()
+              + getBuildChooser()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.BuildChooserSetting.DescriptorImpl {
+              + getBuildChooserDescriptors()
+              + getBuildChooserDescriptors()
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.BuildSingleRevisionOnly {
+              + BuildSingleRevisionOnly()
+              + enableMultipleRevisionDetection()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.BuildSingleRevisionOnly.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.ChangelogToBranch {
+              + ChangelogToBranch()
+              + getOptions()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.ChangelogToBranch.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.CheckoutOption {
+              - timeout : Integer
+              + CheckoutOption()
+              + decorateCheckoutCommand()
+              + decorateCheckoutCommand()
+              + equals()
+              + getTimeout()
+              + hashCode()
+              + requiresWorkspaceForPolling()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.CheckoutOption.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.CleanBeforeCheckout {
+              - deleteUntrackedNestedRepositories : boolean
+              + CleanBeforeCheckout()
+              + decorateFetchCommand()
+              + equals()
+              + hashCode()
+              + isDeleteUntrackedNestedRepositories()
+              + setDeleteUntrackedNestedRepositories()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.CleanBeforeCheckout.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.CleanCheckout {
+              - deleteUntrackedNestedRepositories : boolean
+              + CleanCheckout()
+              + equals()
+              + hashCode()
+              + isDeleteUntrackedNestedRepositories()
+              + onCheckoutCompleted()
+              + setDeleteUntrackedNestedRepositories()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.CleanCheckout.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.CloneOption {
+              - depth : Integer
+              - honorRefspec : boolean
+              - noTags : boolean
+              - reference : String
+              - shallow : boolean
+              - timeout : Integer
+              + CloneOption()
+              + CloneOption()
+              + decorateCloneCommand()
+              + decorateFetchCommand()
+              + equals()
+              + getDepth()
+              + getReference()
+              + getRequiredClient()
+              + getTimeout()
+              + hashCode()
+              + isHonorRefspec()
+              + isNoTags()
+              + isShallow()
+              + setDepth()
+              + setHonorRefspec()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.CloneOption.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.DisableRemotePoll {
+              + DisableRemotePoll()
+              + requiresWorkspaceForPolling()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.DisableRemotePoll.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.GitLFSPull {
+              + GitLFSPull()
+              + decorateCheckoutCommand()
+              + equals()
+              + hashCode()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.GitLFSPull.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.IgnoreNotifyCommit {
+              + IgnoreNotifyCommit()
+              + equals()
+              + hashCode()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.IgnoreNotifyCommit.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.LocalBranch {
+              - localBranch : String
+              + LocalBranch()
+              + equals()
+              + getLocalBranch()
+              + hashCode()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.LocalBranch.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.MessageExclusion {
+              - excludedMessage : String
+              - excludedPattern : Pattern
+              + MessageExclusion()
+              + getExcludedMessage()
+              + isRevExcluded()
+              + requiresWorkspaceForPolling()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.MessageExclusion.DescriptorImpl {
+              + doCheckExcludedMessage()
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.PathRestriction {
+              - excludedPatterns : List<Pattern>
+              - excludedRegions : String
+              - includedPatterns : List<Pattern>
+              - includedRegions : String
+              + PathRestriction()
+              + getExcludedRegions()
+              + getExcludedRegionsNormalized()
+              + getIncludedRegions()
+              + getIncludedRegionsNormalized()
+              + isRevExcluded()
+              + requiresWorkspaceForPolling()
+              - getExcludedPatterns()
+              - getIncludedPatterns()
+              - getRegionsPatterns()
+              - normalize()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.PathRestriction.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.PerBuildTag {
+              + PerBuildTag()
+              + onCheckoutCompleted()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.PerBuildTag.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.PreBuildMerge {
+              + PreBuildMerge()
+              + decorateMergeCommand()
+              + decorateRevisionToBuild()
+              + equals()
+              + getOptions()
+              + getRequiredClient()
+              + hashCode()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.PreBuildMerge.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.PruneStaleBranch {
+              + PruneStaleBranch()
+              + decorateFetchCommand()
+              + equals()
+              + hashCode()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.PruneStaleBranch.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.PruneStaleTag {
+              {static} - TAG_REF : String
+              - pruneTags : boolean
+              + PruneStaleTag()
+              + decorateFetchCommand()
+              + equals()
+              + getPruneTags()
+              + hashCode()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.PruneStaleTag.DescriptorImpl {
+              + getDisplayName()
+              + newInstance()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.RelativeTargetDirectory {
+              - relativeTargetDir : String
+              + RelativeTargetDirectory()
+              + getRelativeTargetDir()
+              + getWorkingDirectory()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.RelativeTargetDirectory.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.ScmName {
+              - name : String
+              + ScmName()
+              + getName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.ScmName.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.SparseCheckoutPath {
+              {static} + SPARSE_CHECKOUT_PATH_TO_PATH : SparseCheckoutPathToPath
+              - path : String
+              {static} - serialVersionUID : long
+              + SparseCheckoutPath()
+              + equals()
+              + getDescriptor()
+              + getPath()
+              + hashCode()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.SparseCheckoutPath.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.SparseCheckoutPath.SparseCheckoutPathToPath {
+              + apply()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.SparseCheckoutPaths {
+              - sparseCheckoutPaths : List<SparseCheckoutPath>
+              + SparseCheckoutPaths()
+              + decorateCheckoutCommand()
+              + decorateCloneCommand()
+              + equals()
+              + getSparseCheckoutPaths()
+              + hashCode()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.SparseCheckoutPaths.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.SubmoduleOption {
+              - depth : Integer
+              - disableSubmodules : boolean
+              - parentCredentials : boolean
+              - recursiveSubmodules : boolean
+              - reference : String
+              - shallow : boolean
+              - threads : Integer
+              - timeout : Integer
+              - trackingSubmodules : boolean
+              + SubmoduleOption()
+              + equals()
+              + getDepth()
+              + getReference()
+              + getShallow()
+              + getThreads()
+              + getTimeout()
+              + hashCode()
+              + isDisableSubmodules()
+              + isParentCredentials()
+              + isRecursiveSubmodules()
+              + isTrackingSubmodules()
+              + onCheckoutCompleted()
+              + onClean()
+              + setDepth()
+              + setShallow()
+              + setThreads()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.SubmoduleOption.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.UserExclusion {
+              - excludedUsers : String
+              + UserExclusion()
+              + getExcludedUsers()
+              + getExcludedUsersNormalized()
+              + isRevExcluded()
+              + requiresWorkspaceForPolling()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.UserExclusion.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.UserIdentity {
+              - email : String
+              - name : String
+              + UserIdentity()
+              + decorate()
+              + equals()
+              + getEmail()
+              + getName()
+              + hashCode()
+              + populateEnvironmentVariables()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.UserIdentity.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.WipeWorkspace {
+              + WipeWorkspace()
+              + beforeCheckout()
+              + equals()
+              + hashCode()
+              + toString()
+          }
+        }
+      }
+    }
+  }
+  
+
+  namespace  {
+    namespace udson.plugins.git {
+      namespace extensions {
+        namespace impl {
+          class hudson.plugins.git.extensions.impl.WipeWorkspace.DescriptorImpl {
+              + getDisplayName()
+          }
+        }
+      }
+    }
+  }
+  
+
+  hudson.plugins.git.extensions.impl.AuthorInChangelog -up-|> hudson.plugins.git.extensions.FakeGitSCMExtension
+  hudson.plugins.git.extensions.impl.AuthorInChangelog +-down- hudson.plugins.git.extensions.impl.AuthorInChangelog.DescriptorImpl
+  hudson.plugins.git.extensions.impl.AuthorInChangelog.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.BuildChooserSetting -up-|> hudson.plugins.git.extensions.FakeGitSCMExtension
+  hudson.plugins.git.extensions.impl.BuildChooserSetting o-- hudson.plugins.git.util.BuildChooser : buildChooser
+  hudson.plugins.git.extensions.impl.BuildChooserSetting +-down- hudson.plugins.git.extensions.impl.BuildChooserSetting.DescriptorImpl
+  hudson.plugins.git.extensions.impl.BuildChooserSetting.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.BuildSingleRevisionOnly -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.BuildSingleRevisionOnly +-down- hudson.plugins.git.extensions.impl.BuildSingleRevisionOnly.DescriptorImpl
+  hudson.plugins.git.extensions.impl.BuildSingleRevisionOnly.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.ChangelogToBranch -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.ChangelogToBranch o-- hudson.plugins.git.ChangelogToBranchOptions : options
+  hudson.plugins.git.extensions.impl.ChangelogToBranch +-down- hudson.plugins.git.extensions.impl.ChangelogToBranch.DescriptorImpl
+  hudson.plugins.git.extensions.impl.ChangelogToBranch.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.CheckoutOption -up-|> hudson.plugins.git.extensions.FakeGitSCMExtension
+  hudson.plugins.git.extensions.impl.CheckoutOption +-down- hudson.plugins.git.extensions.impl.CheckoutOption.DescriptorImpl
+  hudson.plugins.git.extensions.impl.CheckoutOption.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.CleanBeforeCheckout -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.CleanBeforeCheckout +-down- hudson.plugins.git.extensions.impl.CleanBeforeCheckout.DescriptorImpl
+  hudson.plugins.git.extensions.impl.CleanBeforeCheckout.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.CleanCheckout -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.CleanCheckout +-down- hudson.plugins.git.extensions.impl.CleanCheckout.DescriptorImpl
+  hudson.plugins.git.extensions.impl.CleanCheckout.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.CloneOption -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.CloneOption +-down- hudson.plugins.git.extensions.impl.CloneOption.DescriptorImpl
+  hudson.plugins.git.extensions.impl.CloneOption.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.DisableRemotePoll -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.DisableRemotePoll +-down- hudson.plugins.git.extensions.impl.DisableRemotePoll.DescriptorImpl
+  hudson.plugins.git.extensions.impl.DisableRemotePoll.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.GitLFSPull -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.GitLFSPull +-down- hudson.plugins.git.extensions.impl.GitLFSPull.DescriptorImpl
+  hudson.plugins.git.extensions.impl.GitLFSPull.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.IgnoreNotifyCommit -up-|> hudson.plugins.git.extensions.FakeGitSCMExtension
+  hudson.plugins.git.extensions.impl.IgnoreNotifyCommit +-down- hudson.plugins.git.extensions.impl.IgnoreNotifyCommit.DescriptorImpl
+  hudson.plugins.git.extensions.impl.IgnoreNotifyCommit.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.LocalBranch -up-|> hudson.plugins.git.extensions.FakeGitSCMExtension
+  hudson.plugins.git.extensions.impl.LocalBranch +-down- hudson.plugins.git.extensions.impl.LocalBranch.DescriptorImpl
+  hudson.plugins.git.extensions.impl.LocalBranch.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.MessageExclusion -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.MessageExclusion +-down- hudson.plugins.git.extensions.impl.MessageExclusion.DescriptorImpl
+  hudson.plugins.git.extensions.impl.MessageExclusion.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.PathRestriction -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.PathRestriction +-down- hudson.plugins.git.extensions.impl.PathRestriction.DescriptorImpl
+  hudson.plugins.git.extensions.impl.PathRestriction.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.PerBuildTag -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.PerBuildTag +-down- hudson.plugins.git.extensions.impl.PerBuildTag.DescriptorImpl
+  hudson.plugins.git.extensions.impl.PerBuildTag.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.PreBuildMerge -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.PreBuildMerge o-- hudson.plugins.git.UserMergeOptions : options
+  hudson.plugins.git.extensions.impl.PreBuildMerge +-down- hudson.plugins.git.extensions.impl.PreBuildMerge.DescriptorImpl
+  hudson.plugins.git.extensions.impl.PreBuildMerge.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.PruneStaleBranch -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.PruneStaleBranch +-down- hudson.plugins.git.extensions.impl.PruneStaleBranch.DescriptorImpl
+  hudson.plugins.git.extensions.impl.PruneStaleBranch.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.PruneStaleTag -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.PruneStaleTag +-down- hudson.plugins.git.extensions.impl.PruneStaleTag.DescriptorImpl
+  hudson.plugins.git.extensions.impl.PruneStaleTag.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.RelativeTargetDirectory -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.RelativeTargetDirectory +-down- hudson.plugins.git.extensions.impl.RelativeTargetDirectory.DescriptorImpl
+  hudson.plugins.git.extensions.impl.RelativeTargetDirectory.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.ScmName -up-|> hudson.plugins.git.extensions.FakeGitSCMExtension
+  hudson.plugins.git.extensions.impl.ScmName +-down- hudson.plugins.git.extensions.impl.ScmName.DescriptorImpl
+  hudson.plugins.git.extensions.impl.ScmName.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.SparseCheckoutPath .up.|> java.io.Serializable
+  hudson.plugins.git.extensions.impl.SparseCheckoutPath -up-|> hudson.model.AbstractDescribableImpl
+  hudson.plugins.git.extensions.impl.SparseCheckoutPath +-down- hudson.plugins.git.extensions.impl.SparseCheckoutPath.DescriptorImpl
+  hudson.plugins.git.extensions.impl.SparseCheckoutPath +-down- hudson.plugins.git.extensions.impl.SparseCheckoutPath.SparseCheckoutPathToPath
+  hudson.plugins.git.extensions.impl.SparseCheckoutPath.DescriptorImpl -up-|> hudson.model.Descriptor
+  hudson.plugins.git.extensions.impl.SparseCheckoutPath.SparseCheckoutPathToPath .up.|> com.google.common.base.Function
+  hudson.plugins.git.extensions.impl.SparseCheckoutPath.SparseCheckoutPathToPath .up.|> java.io.Serializable
+  hudson.plugins.git.extensions.impl.SparseCheckoutPaths -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.SparseCheckoutPaths +-down- hudson.plugins.git.extensions.impl.SparseCheckoutPaths.DescriptorImpl
+  hudson.plugins.git.extensions.impl.SparseCheckoutPaths.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.SubmoduleOption -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.SubmoduleOption +-down- hudson.plugins.git.extensions.impl.SubmoduleOption.DescriptorImpl
+  hudson.plugins.git.extensions.impl.SubmoduleOption.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.UserExclusion -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.UserExclusion +-down- hudson.plugins.git.extensions.impl.UserExclusion.DescriptorImpl
+  hudson.plugins.git.extensions.impl.UserExclusion.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.UserIdentity -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.UserIdentity +-down- hudson.plugins.git.extensions.impl.UserIdentity.DescriptorImpl
+  hudson.plugins.git.extensions.impl.UserIdentity.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+  hudson.plugins.git.extensions.impl.WipeWorkspace -up-|> hudson.plugins.git.extensions.GitSCMExtension
+  hudson.plugins.git.extensions.impl.WipeWorkspace +-down- hudson.plugins.git.extensions.impl.WipeWorkspace.DescriptorImpl
+  hudson.plugins.git.extensions.impl.WipeWorkspace.DescriptorImpl -up-|> hudson.plugins.git.extensions.GitSCMExtensionDescriptor
+
+
+right footer
+
+
+PlantUML diagram generated by SketchIt! (https://bitbucket.org/pmesmeur/sketch.it)
+For more information about this tool, please contact philippe.mesmeur@gmail.com
+endfooter
+
+@enduml

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -163,9 +163,6 @@ public class GitToolChooser {
      * @return git implementation recommendation in the form of a string
      */
     public String getGitTool() {
-        if (!JGIT_SUPPORTED && gitTool.equals("jgit")) {
-            return "NONE";
-        }
         return gitTool;
     }
 

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -33,7 +33,7 @@ public class GitToolChooser {
      * Size to switch implementation in KiB
      */
     public static final int SIZE_TO_SWITCH = 5000;
-    public boolean JGIT_SUPPORTED = true;
+    public boolean JGIT_SUPPORTED = false;
 
     /**
      * Instantiate class using {@link AbstractGitSCMSource}. It looks for a cached .git directory first, calculates the

--- a/src/main/java/jenkins/plugins/git/GitToolChooser.java
+++ b/src/main/java/jenkins/plugins/git/GitToolChooser.java
@@ -33,6 +33,7 @@ public class GitToolChooser {
      * Size to switch implementation in KiB
      */
     public static final int SIZE_TO_SWITCH = 5000;
+    public boolean JGIT_SUPPORTED = true;
 
     /**
      * Instantiate class using {@link AbstractGitSCMSource}. It looks for a cached .git directory first, calculates the
@@ -59,7 +60,10 @@ public class GitToolChooser {
      * Estimate size of a repository using the extension point
      * @param remoteName: The URL of the repository
      */
-    public GitToolChooser(String remoteName) {
+    public GitToolChooser(String remoteName, Boolean useJGit) {
+        if (useJGit != null) {
+            JGIT_SUPPORTED = useJGit;
+        }
         implementation = determineSwitchOnSize(sizeOfRepo);
         decideAndUseAPI(remoteName);
         determineGitTool(implementation);
@@ -128,10 +132,10 @@ public class GitToolChooser {
      */
     private String determineSwitchOnSize(Long sizeOfRepo) {
         if (sizeOfRepo != 0L) {
-            if (sizeOfRepo >= SIZE_TO_SWITCH) {
-                return "git";
-            } else {
+            if (sizeOfRepo < SIZE_TO_SWITCH && JGIT_SUPPORTED) {
                 return "jgit";
+            } else {
+                return "git";
             }
         }
         return "NONE";
@@ -159,6 +163,9 @@ public class GitToolChooser {
      * @return git implementation recommendation in the form of a string
      */
     public String getGitTool() {
+        if (!JGIT_SUPPORTED && gitTool.equals("jgit")) {
+            return "NONE";
+        }
         return gitTool;
     }
 

--- a/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
+++ b/src/test/java/jenkins/plugins/git/GitToolChooserTest.java
@@ -88,8 +88,9 @@ public class GitToolChooserTest {
      */
     @Test
     public void testSizeEstimationWithAPIForGit() {
+        boolean useJGit = false;
         String remote = "https://gitlab.com/rishabhBudhouliya/git-plugin.git";
-        GitToolChooser sizeEstimator = new GitToolChooser(remote);
+        GitToolChooser sizeEstimator = new GitToolChooser(remote, useJGit);
         assertThat(sizeEstimator.getGitTool(), containsString("git"));
     }
 
@@ -99,10 +100,11 @@ public class GitToolChooserTest {
      */
     @Test
     public void testSizeEstimationWithAPIForJGit() {
+        boolean useJGit = true;
         String remote = "https://github.com/rishabhBudhouliya/git-plugin.git";
         jenkins.jenkins.getDescriptorByType(GitTool.DescriptorImpl.class).setInstallations(new JGitTool(Collections.<ToolProperty<?>>emptyList()));
 
-        GitToolChooser sizeEstimator = new GitToolChooser(remote);
+        GitToolChooser sizeEstimator = new GitToolChooser(remote, useJGit);
         assertThat(sizeEstimator.getGitTool(), containsString("jgit"));
     }
 
@@ -112,8 +114,9 @@ public class GitToolChooserTest {
      */
     @Test
     public void testSizeEstimationWithBitbucketAPIs() {
+        boolean useJGit = true;
         String remote = "https://bitbucket.com/rishabhBudhouliya/git-plugin.git";
-        GitToolChooser sizeEstimator = new GitToolChooser(remote);
+        GitToolChooser sizeEstimator = new GitToolChooser(remote, useJGit);
         assertThat(sizeEstimator.getGitTool(), is("NONE"));
     }
 
@@ -125,7 +128,7 @@ public class GitToolChooserTest {
     @Test
     public void testSizeEstimationWithException() {
         String remote = "https://bitbucket.com/rishabhBudhouliya/git-plugin.git";
-        GitToolChooser sizeEstimator = new GitToolChooser(remote);
+        GitToolChooser sizeEstimator = new GitToolChooser(remote, true);
 
         assertThat(sizeEstimator.getGitTool(), is("NONE"));
     }


### PR DESCRIPTION
## Enabling GitToolChooser to recommend a git implementation knowing if the implementation is compatible with certain features of git

The introduction of UnsupportedCommand allows us to solve cases where JGit might not be supported and GitToolChooser might suggest JGit because of the size rule. The GitToolChooser can use this command to know if JGit can be user or not.
This working of this command and its usage has been explained below:

## Using UnsupportedCommand in Git Plugin

- Add a method in GitSCMExtension: `determineSupportForJGit`
This method acts as a way for the extensions to convey their support for JGit over certain functionalities.

- Add implementation of `determineSupportForGit` for various extensions: GitLFSPull, SparseCheckoutPaths, SubmoduleOption, CheckoutOption etc.
These implementations will put information into an `unsupportedCommand` object about the compatibility of a certain extension feature with JGit.

- An example of how GitToolChooser will work within the Git Plugin
Refer to [this commit](https://github.com/jenkinsci/git-plugin/commit/4a2bd5771601ddc0fad870872231e5df4e6bb787). 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] Documentation in README has been updated as necessary
- [ ] Online help has been added and reviewed for any new or modified fields
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
